### PR TITLE
Cope with system's endianness in unit test for writebinblock

### DIFF
--- a/inst/writebinblock.m
+++ b/inst/writebinblock.m
@@ -116,7 +116,13 @@ endfunction
 %!
 %! writebinblock(a, "hello", "uint16");
 %! x = read(a);
-%! assert(char(x), "#210h\0e\0l\0l\0o\0\n");
+%! [comp, maxsize, endian] = computer ();
+%! if endian == "L"
+%!   expected = "#210h\0e\0l\0l\0o\0\n";
+%! else
+%!   expected = "#210\0h\0e\0l\0l\0o\n";
+%! endif
+%! assert(char(x), expected);
 %! clear a
 
 %!test


### PR DESCRIPTION
On a s390x system, the unit test for writebinblock` fails with the following message:

```
octave:1> pkg load instrument-control
octave:2> test writebinblock
***** test
 # old classes
 a = udp ();
 a.remoteport = a.localport;
 a.remotehost = '127.0.0.1';
 a.timeout = 1;

 writebinblock(a, "hello", "char");
 x = read(a);
 assert(char(x), "#15hello\n");

 writebinblock(a, "hello", "uint16");
 x = read(a);
 assert(char(x), "#210h\0e\0l\0l\0o\0\n");
 clear a
!!!!! test failed
ASSERT errors for:  assert (char (x),"#210h\0e\0l\0l\0o\0\n")

  Location  |  Observed  |  Expected  |  Reason
     []      '#210hello
' '#210hello
'   Strings don't match
```

The problem is related to endianness (s390x is big-endian). The commit in the present PR fixes the issue by adjusting the expected result in the unit test according to the system's architecture. I did not investigate whether a more principled fix to the main code of the `writebinblock` function would be more appropriate.